### PR TITLE
Smoothtrain

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,6 +14,8 @@
   ],
   "dependencies": {
     "jquery": "~2.1.3",
+    "jquery-ui": "~1.11.4",
+    "jquery-dotimeout": "v1.0",
     "less": "~2.4.0",
     "modernizr": "~2.8.3"
   }

--- a/configs/master.js
+++ b/configs/master.js
@@ -13,6 +13,8 @@ module.exports = {
 
         "bower_components/modernizr/modernizr.js",
         "bower_components/jquery/dist/jquery.js",
+        "bower_components/jquery-ui/ui/effect.js",
+        "bower_components/jquery-dotimeout/jquery.ba-dotimeout.min.js",
         "public/train.js",
         "public/ga.js",
 

--- a/public/train.js
+++ b/public/train.js
@@ -1,7 +1,6 @@
 /* jshint browser: true */
 
 jQuery(function($) {
-    var Modernizr = window.Modernizr;
     var $window = $(window);
     var $track = $('#track');
     var $rails = $('#rails');
@@ -10,18 +9,10 @@ jQuery(function($) {
     var trainRange = $rails.height();
     var trainHeight = $train.height();
     var trainOffset = 0 - trainHeight;
-    var transformPrefixed = Modernizr.prefixed('transform');
 
-    var move = Modernizr.csstransforms && Modernizr.csstransforms3d ? function(top) {
-        if (top > trainHeight) {
-            $train.css(transformPrefixed, 'translate3d(0,' + (trainOffset + top) + 'px,0)');
-        }
-        else {
-            $train.css(transformPrefixed, 'translate(0,' + (trainOffset + top) + 'px)');
-        }
-    } : function(top) {
-        $train.css({
-            top: (trainOffset + top) + 'px',
+    var move = function(top) {
+        $.doTimeout('scroll', 400 , function() {
+            $train.animate({'top': trainOffset+top+'px'}, 500, 'easeInOutCubic');
         });
     };
 


### PR DESCRIPTION
Instead of using JS to set CSS transformations, do all animation using JS.

Use custom animation easing 'easeInOutCubic' to make train start up and slow down.

fixes #15
